### PR TITLE
build: add explicit vrs-python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ga4gh.vrs>=2.2.0, <3",
+    "ga4gh.vrs>=2.2.0,<3.0",
     "ga4gh.va_spec~=0.4.2",
     "biocommons.anyvar@git+https://github.com/biocommons/anyvar.git@main",
     "fastapi>=0.95.0",


### PR DESCRIPTION
Not a biggy, but we technically should be declaring a VRS-Python dependency because we make use of the Allele model.