### PR TITLE
cicd: cache chainfile downloads in actions

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/wags_tails/ucsc-chainfile/
-          key: ${{ runner.os }}-test-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-test-${{ hashFiles('pyproject.toml') }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Recently we had a test fail because the chainfile wouldnt download (might've been throttling us, or just a brief UCSC service outage): https://github.com/biocommons/anyvar/actions/runs/20938360818/job/60166285476?pr=374

This action caches that download so it should happen less