### PR TITLE
fix: use correct version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anyvlm"
-version="1.0.0"
+version="1.0.1"
 authors = [
   { name="biocommons contributors", email="biocommons-dev@googlegroups.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "anyvlm"
-version="1.0.0-rc2"
+version="1.0.0"
 authors = [
   { name="biocommons contributors", email="biocommons-dev@googlegroups.com" },
 ]


### PR DESCRIPTION
1.0.0 release was made, but the pyproject.toml wasn't updated... should I just bump this to 1.0.1?