### PR TITLE
fix(ci): fix 04_export_eb_env_var

### DIFF
--- a/.ebextensions/01_download_data.config
+++ b/.ebextensions/01_download_data.config
@@ -6,7 +6,7 @@ commands:
     03_eb_packages:
        command: "/var/app/venv/staging-LQM1lest/bin/pip install uvloop websockets httptools typing-extensions boto3 botocore"
     04_export_eb_env_var:
-        command: "export $(cat /opt/elasticbeanstalk/deployment/env | xargs)"
+        command: "source /opt/elasticbeanstalk/deployment/env"
 
 container_commands:
     01_s3_download:


### PR DESCRIPTION
Was failing to export `HANDOVER_TYPE_LABEL=GREGoR AnyVLM Reference, U10 Cohort` due to the comma